### PR TITLE
[DO NOT MERGE] Custom paper_trail YAML serializer for JobReady

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in jr_paper_trail_yaml_serializer.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    jr_paper_trail_yaml_serializer (0.0.3)
+      paperclip (~> 3.5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.1.8)
+      activesupport (= 4.1.8)
+      builder (~> 3.1)
+    activesupport (4.1.8)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.4)
+      climate_control (>= 0.0.3, < 1.0)
+    diff-lcs (1.2.5)
+    i18n (0.6.11)
+    json (1.8.1)
+    mime-types (2.4.3)
+    minitest (5.4.3)
+    paperclip (3.5.4)
+      activemodel (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      cocaine (~> 0.5.3)
+      mime-types
+    rake (10.4.1)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.7)
+  jr_paper_trail_yaml_serializer!
+  rake (~> 10.0)
+  rspec (~> 3.1.0)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2014 Brad Bollenbach
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# JobReady's paper_trail YAML Serializer
+
+paper_trail's default YAML serializer doesn't play nicely with
+carrierwave-cascade. The YAML serializer defined in this gem
+does. :)
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'jr_paper_trail_yaml_serializer', github: 'jobready/jr_paper_trail_yaml_serializer'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install jr_paper_trail_yaml_serializer
+
+## Usage
+
+**Note: You only need to use this gem if you're using carrierwave-cascade and
+paper_trail.**
+
+Create a `config/initializers/paper_trail.rb` file, containing the following:
+
+```ruby
+PaperTrail.serializer = PaperTrail::Serializers::JobReady::YAML
+```
+
+That's it!
+
+## Contributing
+
+1. Fork it ( https://github.com/[my-github-username]/jr_paper_trail_yaml_serializer/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+

--- a/jr_paper_trail_yaml_serializer.gemspec
+++ b/jr_paper_trail_yaml_serializer.gemspec
@@ -1,0 +1,25 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'jr_paper_trail_yaml_serializer/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "jr_paper_trail_yaml_serializer"
+  spec.version       = JrPaperTrailYamlSerializer::VERSION
+  spec.authors       = ["Brad Bollenbach"]
+  spec.email         = ["bradb@jobready.com.au"]
+  spec.summary       = %q{A YAML serializer for paper_trail, that works with carrierwave-cascade}
+  spec.description   = %q{}
+  spec.homepage      = "https://github.com/jobready/jr_paper_trail_yaml_serializer"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency 'paperclip', '~> 3.5.0'
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.1.0"
+end

--- a/lib/jr_paper_trail_yaml_serializer.rb
+++ b/lib/jr_paper_trail_yaml_serializer.rb
@@ -1,0 +1,2 @@
+require "jr_paper_trail_yaml_serializer/version"
+require "paper_trail/serializers/job_ready/yaml"

--- a/lib/jr_paper_trail_yaml_serializer/version.rb
+++ b/lib/jr_paper_trail_yaml_serializer/version.rb
@@ -1,0 +1,3 @@
+module JrPaperTrailYamlSerializer
+  VERSION = "0.0.4"
+end

--- a/lib/paper_trail/serializers/job_ready/yaml.rb
+++ b/lib/paper_trail/serializers/job_ready/yaml.rb
@@ -1,0 +1,39 @@
+require 'yaml'
+
+# Custom YAML sanitizer for JobReady projects. Fixes issues with serialising
+# carrierwave columns when carrierwave-cascade is involved.
+module PaperTrail
+  module Serializers
+    module JobReady
+      module YAML
+        extend self
+
+        def load(yaml_string)
+          ::YAML.load(yaml_string)
+        end
+
+        def dump(object)
+          sanitized_object = {}
+
+          object.each do |k, v|
+            sanitized_object[k] =
+              v.is_a?(Array) ? sanitize_array(v) : sanitize_non_array(v)
+          end
+
+          ::YAML.dump(sanitized_object)
+        end
+
+        private
+
+        def sanitize_array(array)
+          array.map { |item| sanitize_non_array(item) }
+        end
+
+        def sanitize_non_array(value)
+          value.is_a?(CarrierWave::Uploader::Base) ? value.url : value
+        end
+      end
+    end
+  end
+end
+

--- a/spec/paper_trail/serializers/job_ready/yaml_spec.rb
+++ b/spec/paper_trail/serializers/job_ready/yaml_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+module CarrierWave
+  module Uploader
+    class Base
+      def url
+        "http://test.url"
+      end
+    end
+  end
+end
+
+RSpec.describe PaperTrail::Serializers::JobReady::YAML do
+  subject { described_class }
+
+  let(:uploader_1) do
+    CarrierWave::Uploader::Base.new
+  end
+
+  let(:uploader_2) do
+    CarrierWave::Uploader::Base.new
+  end
+
+  describe ".dump" do
+    context "serializing a hash containing CarrierWave::Uploader::Base values in it" do
+      it "serializes the C::U::B urls" do
+        expect(subject.dump(foo: "bar", baz: uploader_1)).
+          to eq("---\n:foo: bar\n:baz: http://test.url\n")
+      end
+   end
+
+    context "serializing a hash containing Array values, that have
+             CarrierWave::Uploader::Base elements in them" do
+      it "serializes the C::U::B urls" do
+        expect(subject.dump(foo: ["bar", "baz"], baz: [uploader_1, uploader_2])).
+          to eq("---\n:foo:\n- bar\n- baz\n:baz:\n- http://test.url\n- http://test.url\n")
+      end
+    end
+
+    context "serializing a hash with no CarrierWave::Uploader::Base elements in it" do
+      it "serializes the values without any special sanitizing" do
+        expect(subject.dump(foo: "bar")).to eq("---\n:foo: bar\n")
+      end
+    end
+  end
+
+  describe ".load" do
+    it "loads objects from YAML" do
+      expect(subject.load("---\n:foo: bar\n")).to eq(foo: "bar")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'bundler/setup'
+Bundler.setup
+
+require 'jr_paper_trail_yaml_serializer'


### PR DESCRIPTION
paper_trail's YAML serializer breaks with carrierwave-cascade. This is a custom serializer to work around this issue, by special-casing carrierwave file attrs to store just the URL.
